### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: ${{ secrets.REGISTRY_URL }}
+      IMAGE_NAME: ncos-phoenix
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install Poetry and project dependencies
+        run: |
+          pip install poetry
+          poetry install
+      - name: Run black
+        run: |
+          poetry run black --check .
+      - name: Run flake8
+        run: |
+          poetry run flake8 .
+      - name: Run mypy
+        run: |
+          poetry run mypy .
+      - name: Run pytest
+        run: |
+          poetry run pytest
+      - name: Login to registry
+        run: |
+          echo "${{ secrets.REGISTRY_PASSWORD }}" | docker login ${{ env.REGISTRY }} -u "${{ secrets.REGISTRY_USERNAME }}" --password-stdin
+      - name: Build Docker image
+        run: |
+          docker build -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} .
+      - name: Push Docker image
+        run: |
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+      - name: Deploy
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          echo "Deploying image ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}"
+          # Example deployment command (replace with your actual deployment)
+          # ssh ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} 'docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} && docker run -d -p 8000:8000 ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}'


### PR DESCRIPTION
## Summary
- add CI workflow for linting, type checks, tests, Docker build and optional deploy

## Testing
- `black --check . | head`
- `flake8 | head -n 10`
- `mypy . > /tmp/mypy.log && tail -n 20 /tmp/mypy.log`
- `pytest -q`
- `docker build -t test-image .` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_685802dd75a4832ea7bc808517681c59