### PR TITLE
Improve error handling in analytics engines

### DIFF
--- a/src/ncos/engines/run_zanalytics_session.py
+++ b/src/ncos/engines/run_zanalytics_session.py
@@ -3,6 +3,7 @@ import os
 import argparse
 import sys
 from datetime import datetime
+import logging
 from trait_engine import merge_config
 from core.intermarket_sentiment import snapshot_sentiment
 from copilot_orchestrator import run_full_analysis
@@ -19,88 +20,144 @@ import re
 from runtime.data_pipeline import DataPipeline
 import pandas as pd
 
+logging.basicConfig(level=logging.INFO,
+                    format='%(asctime)s - %(levelname)s - %(message)s')
+
 
 def load_configs(config_dir):
+    """Load config JSON files from a directory.
+
+    Missing or malformed files are logged and skipped so the
+    application can continue with partial configs.
+    """
     files = ['copilot_config.json', 'chart_config.json', 'strategy_profiles.json']
     configs = {}
     for fname in files:
         path = os.path.join(config_dir, fname)
         if not os.path.exists(path):
-            raise FileNotFoundError(f"Configuration file not found: {path}")
-        with open(path) as f:
-            configs[fname.split('_')[0]] = json.load(f)
-    merge_config(
-        configs['copilot'],
-        configs['chart'],
-        configs['strategy']
-    )
-    print("[Config] Configurations merged.")
+            logging.error("Config file missing: %s", path)
+            configs[fname.split('_')[0]] = {}
+            continue
+        try:
+            with open(path) as f:
+                configs[fname.split('_')[0]] = json.load(f)
+        except Exception as e:  # pragma: no cover - unexpected read error
+            logging.error("Failed loading %s: %s", path, e)
+            configs[fname.split('_')[0]] = {}
+
+    try:
+        merge_config(
+            configs.get('copilot', {}),
+            configs.get('chart', {}),
+            configs.get('strategy', {})
+        )
+    except Exception as e:
+        logging.error("Config merge failed: %s", e)
+
+    logging.info("[Config] Configurations merged.")
     return configs
 
 
 def initialize_data():
-    # Use DataPipeline to fetch and resample raw M1 to HTF CSVs
-    dp = DataPipeline(config=None)  # config not needed here
-    dp.fetch_pairs()
-    dp.resample_htf()
+    """Fetch and load all timeframe data.
 
-    # Load HTF data from CSVs
+    Any errors during fetching or loading will be logged and an
+    empty dictionary returned so calling code can decide how to
+    proceed.
+    """
+    try:
+        dp = DataPipeline(config=None)  # config not needed here
+        dp.fetch_pairs()
+        dp.resample_htf()
+    except Exception as e:
+        logging.error("DataPipeline execution failed: %s", e)
+        return {}
+
     all_tf = {}
     pattern = re.compile(rf"([A-Z]+)_(?P<tf>[A-Za-z0-9]+)_.*\.csv")
     htf_dir = Path("tick_data/htf")
     for path in htf_dir.glob("*.csv"):
-        m = pattern.match(path.name)
-        if not m:
-            print(f"[WARN] Skipping file {path.name}")
-            continue
-        tf = m.group('tf').lower()
-        df = pd.read_csv(path, parse_dates=True, index_col=0)
-        all_tf[tf] = df
-        print(f"[INFO] Loaded {tf.upper()} from {path.name}")
+        try:
+            m = pattern.match(path.name)
+            if not m:
+                logging.warning("Skipping unexpected file %s", path.name)
+                continue
+            tf = m.group('tf').lower()
+            df = pd.read_csv(path, parse_dates=True, index_col=0)
+            all_tf[tf] = df
+            logging.info("Loaded %s from %s", tf.upper(), path.name)
+        except Exception as e:
+            logging.error("Failed loading %s: %s", path.name, e)
     return all_tf
 
 
 def inject_sentiment(output_path, macro_version):
-    snapshot = snapshot_sentiment()
+    """Create and persist a sentiment snapshot.
+
+    If snapshot retrieval or saving fails, an empty snapshot is returned
+    so downstream processing can continue.
+    """
+    try:
+        snapshot = snapshot_sentiment()
+    except Exception as e:
+        logging.error("Snapshot sentiment failed: %s", e)
+        snapshot = {}
+
     snapshot['run_meta'] = {
         'timestamp': datetime.utcnow().isoformat(),
         'strategy_version': macro_version,
         'macro_bias': snapshot.get('context_overall_bias')
     }
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)
-    with open(output_path, 'w') as f:
-        json.dump(snapshot, f, indent=2)
-    print("[Sentiment] Snapshot saved.")
+
+    try:
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, 'w') as f:
+            json.dump(snapshot, f, indent=2)
+    except Exception as e:
+        logging.error("Failed writing sentiment snapshot: %s", e)
+    else:
+        logging.info("[Sentiment] Snapshot saved.")
+
     return snapshot
 
 
 def run_analysis(multi_tf, sentiment, output_dir, macro_version):
-    smc = AdvancedSMCOrchestrator(multi_tf, sentiment['context_overall_bias'])
-    result_smc = smc.run()
+    """Run the full analytics stack with graceful error handling."""
+    try:
+        smc = AdvancedSMCOrchestrator(multi_tf, sentiment['context_overall_bias'])
+        result_smc = smc.run()
 
-    sweeps = detect_liquidity_sweeps(multi_tf)
-    poi_scores = predict_poi_quality(result_smc['pois'])
+        sweeps = detect_liquidity_sweeps(multi_tf)
+        poi_scores = predict_poi_quality(result_smc['pois'])
 
-    result_full = run_full_analysis(
-        data=multi_tf,
-        sentiment_context=sentiment.get('context_overall_bias'),
-        sweeps=sweeps,
-        poi_scores=poi_scores
-    )
+        result_full = run_full_analysis(
+            data=multi_tf,
+            sentiment_context=sentiment.get('context_overall_bias'),
+            sweeps=sweeps,
+            poi_scores=poi_scores
+        )
+    except Exception as e:
+        logging.error("Analysis pipeline failed: %s", e)
+        return {}
 
     result_full['run_meta'] = {
         'timestamp': datetime.utcnow().isoformat(),
         'strategy_version': macro_version
     }
 
-    os.makedirs(output_dir, exist_ok=True)
-    log_path = os.path.join(output_dir, 'zanalytics_log.json')
-    with open(log_path, 'w') as f:
-        json.dump(result_full['log'], f, indent=2)
-    summary_path = os.path.join(output_dir, 'summary_zanalytics.md')
-    with open(summary_path, 'w') as f:
-        f.write(result_full['summary'])
-    print("[Analysis] Full analysis complete.")
+    try:
+        os.makedirs(output_dir, exist_ok=True)
+        log_path = os.path.join(output_dir, 'zanalytics_log.json')
+        with open(log_path, 'w') as f:
+            json.dump(result_full.get('log', {}), f, indent=2)
+        summary_path = os.path.join(output_dir, 'summary_zanalytics.md')
+        with open(summary_path, 'w') as f:
+            f.write(result_full.get('summary', ''))
+    except Exception as e:
+        logging.error("Failed writing analysis output: %s", e)
+    else:
+        logging.info("[Analysis] Full analysis complete.")
+
     return result_full
 
 
@@ -118,7 +175,7 @@ def parse_args():
 
 
 def main():
-    print("[ZANALYTICS] Starting session v5.2")
+    logging.info("[ZANALYTICS] Starting session v5.2")
     args = parse_args()
     configs = load_configs(args.config_dir)
     multi_tf = initialize_data()
@@ -134,10 +191,13 @@ def main():
         macro_version=args.strategy_version
     )
 
-    feedback = analyze_feedback(analysis_results)
-    run_optimizer_loop(analysis_results, feedback)
-
-    print("[ZANALYTICS] Session complete.")
+    if analysis_results:
+        try:
+            feedback = analyze_feedback(analysis_results)
+            run_optimizer_loop(analysis_results, feedback)
+        except Exception as e:
+            logging.error("Post-analysis processing failed: %s", e)
+    logging.info("[ZANALYTICS] Session complete.")
 
 
 if __name__ == '__main__':

--- a/src/ncos/engines/zdx_core.py
+++ b/src/ncos/engines/zdx_core.py
@@ -6,6 +6,7 @@ import hmac
 import base64
 import hashlib
 import requests
+import logging
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -39,6 +40,12 @@ def place_order(symbol, price, quantity=0.01):
         "Authorization": auth_header,
         "Content-Type": "application/json"
     }
-    response = requests.post(DX_BASE_URL + uri, headers=headers, data=content)
-    print("[ZDX] Order Status:", response.status_code, response.text)
-    return response
+    try:
+        response = requests.post(
+            DX_BASE_URL + uri, headers=headers, data=content, timeout=10
+        )
+        logging.info("[ZDX] Order Status: %s %s", response.status_code, response.text)
+        return response
+    except requests.RequestException as e:
+        logging.error("[ZDX] Order placement failed: %s", e)
+        return None

--- a/tests/test_zanalytics_failure_paths.py
+++ b/tests/test_zanalytics_failure_paths.py
@@ -1,0 +1,48 @@
+import json
+from pathlib import Path
+import types
+import pytest
+
+import sys
+sys.modules.setdefault('trait_engine', types.ModuleType('trait_engine'))
+sys.modules['trait_engine'].merge_config = lambda *a, **k: None
+sys.modules.setdefault('copilot_orchestrator', types.ModuleType('copilot_orchestrator'))
+sys.modules['copilot_orchestrator'].run_full_analysis = lambda *a, **k: {}
+sys.modules.setdefault('advanced_smc_orchestrator', types.ModuleType('advanced_smc_orchestrator'))
+sys.modules['advanced_smc_orchestrator'].AdvancedSMCOrchestrator = lambda *a, **k: types.SimpleNamespace(run=lambda: {'pois': []})
+sys.modules.setdefault('liquidity_vwap_detector', types.ModuleType('liquidity_vwap_detector'))
+sys.modules['liquidity_vwap_detector'].detect_liquidity_sweeps = lambda *a, **k: {}
+sys.modules.setdefault('optimizer_loop', types.ModuleType('optimizer_loop'))
+sys.modules['optimizer_loop'].run_optimizer_loop = lambda *a, **k: None
+sys.modules.setdefault('feedback_analysis_engine', types.ModuleType('feedback_analysis_engine'))
+sys.modules['feedback_analysis_engine'].analyze_feedback = lambda *a, **k: {}
+sys.modules.setdefault('poi_quality_predictor', types.ModuleType('poi_quality_predictor'))
+sys.modules['poi_quality_predictor'].predict_poi_quality = lambda *a, **k: {}
+
+import sys
+sys.modules.setdefault('core.intermarket_sentiment', types.ModuleType('core.intermarket_sentiment'))
+sys.modules['core.intermarket_sentiment'].snapshot_sentiment = lambda: {}
+sys.modules.setdefault('runtime.data_pipeline', types.ModuleType('runtime.data_pipeline'))
+sys.modules['runtime.data_pipeline'].DataPipeline = lambda config=None: types.SimpleNamespace(fetch_pairs=lambda: None, resample_htf=lambda: None)
+sys.modules.setdefault('pandas', types.ModuleType('pandas'))
+sys.modules['pandas'].read_csv = lambda *a, **k: None
+
+import src.ncos.engines.run_zanalytics_session as rz
+
+
+def test_load_configs_missing(tmp_path):
+    cfg = rz.load_configs(tmp_path)
+    assert cfg['copilot'] == {}
+    assert cfg['chart'] == {}
+    assert cfg['strategy'] == {}
+
+
+def test_initialize_data_failure(monkeypatch):
+    class DummyPipeline:
+        def fetch_pairs(self):
+            raise RuntimeError('fetch fail')
+        def resample_htf(self):
+            pass
+    monkeypatch.setattr(rz, 'DataPipeline', lambda config=None: DummyPipeline())
+    result = rz.initialize_data()
+    assert result == {}

--- a/tests/test_zdx_core_error_handling.py
+++ b/tests/test_zdx_core_error_handling.py
@@ -1,0 +1,33 @@
+import types
+import pytest
+import sys
+
+class DummyRequestsModule(types.ModuleType):
+    class RequestException(Exception):
+        pass
+
+    def __init__(self):
+        super().__init__('requests')
+        self.post = lambda *a, **k: None
+
+sys.modules['requests'] = DummyRequestsModule()
+import requests
+
+sys.modules.setdefault('dotenv', types.ModuleType('dotenv'))
+sys.modules['dotenv'].load_dotenv = lambda *a, **k: None
+sys.modules.setdefault('dotenv.main', types.ModuleType('main'))
+
+import os
+os.environ.setdefault('DX_PRIVATE_KEY', 'dummy')
+os.environ.setdefault('DX_PUBLIC_KEY', 'dummy')
+os.environ.setdefault('DX_ACCOUNT_CODE', 'dummy')
+
+import src.ncos.engines.zdx_core as zdx
+
+
+def test_place_order_network_failure(monkeypatch):
+    def mock_post(*args, **kwargs):
+        raise requests.RequestException("network down")
+    monkeypatch.setattr(zdx.requests, "post", mock_post)
+    result = zdx.place_order("EURUSD", 1.1)
+    assert result is None


### PR DESCRIPTION
## Summary
- harden `run_zanalytics_session` with logging and graceful fallbacks
- add error handling to `zdx_core.place_order`
- test network failures and bad pipeline states

## Testing
- `pytest tests/test_zdx_core_error_handling.py tests/test_zanalytics_failure_paths.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: trait_engine)*

------
https://chatgpt.com/codex/tasks/task_b_68581656a488832eabcd3b372a1cb55d